### PR TITLE
Properly encode OData params; improve test client query

### DIFF
--- a/src/Linq2OData.Core/ODataClient.cs
+++ b/src/Linq2OData.Core/ODataClient.cs
@@ -162,12 +162,12 @@ namespace Linq2OData.Core
 
             if (!string.IsNullOrWhiteSpace(expand))
             {
-                queryParameters.Add($"$expand={expand}");
+                queryParameters.Add($"$expand={Uri.EscapeDataString(expand)}");
             }
 
             if (!string.IsNullOrWhiteSpace(filter))
             {
-                queryParameters.Add($"$filter={filter}");
+                queryParameters.Add($"$filter={Uri.EscapeDataString(filter)}");
             }
 
             if (!string.IsNullOrWhiteSpace(orderby))

--- a/test/Linq2OData.TestClients/Program.cs
+++ b/test/Linq2OData.TestClients/Program.cs
@@ -32,14 +32,28 @@ namespace Linq2OData.TestClients
 
             var tripPinClient = new TripPin.TripPinClient(httpClient);
 
-            var result = await tripPinClient
-                .Query<TripPin.Microsoft.OData.SampleService.Models.TripPin.Person>()
-                .Top(1)
-                .Expand(e => e.Trips!.Select(e => e.PlanItems))
+            try
+            {
 
-                .ExecuteAsync();
+                var result = await tripPinClient
+                    .Query<TripPin.Microsoft.OData.SampleService.Models.TripPin.Person>()
+                    .Top(10)
+                    .Filter(e => e.FirstName != "Uno")
+                    .Expand(e => e.Trips!.Select(e => e.PlanItems))
+                       .ExecuteAsync();
 
-            Console.WriteLine($"Success! Got {result?.Count} people with {result?[0].Trips?.Count} trips");
+                Console.WriteLine($"Success! Got {result?.Count} people with {result?[0].Trips?.Count} trips");
+            }
+            catch (Exception ex)
+            {
+                var t = ex;
+                throw;
+            }
+
+
+             
+
+      
         }
 
         private static async Task TestV2ClientAsync()


### PR DESCRIPTION
Ensure $expand and $filter are URL-encoded in ODataClient to handle special characters safely.