### PR TITLE
Capitalize ActionsPropertyName in MetadataExtensions

### DIFF
--- a/src/Linq2OData.Generator/MetadataExtensions.cs
+++ b/src/Linq2OData.Generator/MetadataExtensions.cs
@@ -59,7 +59,9 @@ internal static class MetadataExtensions
         internal string HelperName => $"{navigation.NamespaceName}_Helper";
         internal string ServiceName => $"{navigation.NamespaceName}_Service";
         internal string ActionsClassName => $"{navigation.NamespaceName}_Actions";
-        internal string ActionsPropertyName => navigation.NamespaceName;
+        internal string ActionsPropertyName => string.IsNullOrEmpty(navigation.NamespaceName)
+            ? navigation.NamespaceName
+            : char.ToUpperInvariant(navigation.NamespaceName[0]) + navigation.NamespaceName.Substring(1);
         internal string ActionsFieldName => $"{Helpers.ToCamelCaseVariable(navigation.NamespaceName)}";
 
         internal string MetadataAsJson => System.Text.Json.JsonSerializer.Serialize(navigation.Metadata);


### PR DESCRIPTION
Updated ActionsPropertyName to return NamespaceName with an uppercase first letter when not empty, improving naming consistency in generated code.